### PR TITLE
chore(release): marko-zag 2.0.0-rc.3 — bump @zag-js to 1.43.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.0-rc.3] - 2026-08-30
+
+### Changed
+
+- **BREAKING** — every `@zag-js/*` dependency (`core`, `types`, `utils`, and
+  the machine devDependencies `checkbox`, `combobox`, `qr-code`, `select`,
+  `tooltip`) is pinned to exact `1.43.3`, up from the `^1.43.0` range
+  (installed `1.43.0`). No external users and no compatibility commitment on
+  this adapter, so the range is dropped for an exact pin rather than widened.
+
+### Fixed
+
+- `tests/type-assertions.ts`'s `ZagSchema<M>["props"]` pin: zag 1.43.3
+  tightened the machine schema so `props` is now a real
+  (`RequiredBy<Props, ...>`) type instead of `any`. The assertion is updated
+  to require `"notany"` instead of `"any"`; `checkbox.Props` remains the
+  precision path a component's `Input` should extend.
+
 ## [2.0.0-rc.2] - 2026-08-27
 
 ### Changed
@@ -349,7 +367,8 @@ service.rev                           service
 
 - `stripOwnProps` native-attrs helper.
 
-[Unreleased]: https://github.com/svallory/marko-zag/compare/v2.0.0-rc.2...HEAD
+[Unreleased]: https://github.com/svallory/marko-zag/compare/v2.0.0-rc.3...HEAD
+[2.0.0-rc.3]: https://github.com/svallory/marko-zag/compare/v2.0.0-rc.2...v2.0.0-rc.3
 [2.0.0-rc.2]: https://github.com/svallory/marko-zag/compare/v2.0.0-rc.1...v2.0.0-rc.2
 [2.0.0-rc.1]: https://github.com/svallory/marko-zag/compare/v1.2.1...v2.0.0-rc.1
 [1.2.1]: https://github.com/svallory/marko-zag/compare/v1.2.0...v1.2.1

--- a/bun.lock
+++ b/bun.lock
@@ -5,20 +5,20 @@
     "": {
       "name": "marko-zag",
       "dependencies": {
-        "@zag-js/core": "^1.43.0",
-        "@zag-js/types": "^1.43.0",
-        "@zag-js/utils": "^1.43.0",
+        "@zag-js/core": "1.43.3",
+        "@zag-js/types": "1.43.3",
+        "@zag-js/utils": "1.43.3",
       },
       "devDependencies": {
         "@docmd/core": "^0.9.2",
         "@marko/type-check": "^2.0.0",
         "@marko/vite": "5",
         "@vitest/browser": "3.2.7",
-        "@zag-js/checkbox": "^1.43.0",
-        "@zag-js/combobox": "^1.43.0",
-        "@zag-js/qr-code": "^1.43.0",
-        "@zag-js/select": "^1.43.0",
-        "@zag-js/tooltip": "^1.43.0",
+        "@zag-js/checkbox": "1.43.3",
+        "@zag-js/combobox": "1.43.3",
+        "@zag-js/qr-code": "1.43.3",
+        "@zag-js/select": "1.43.3",
+        "@zag-js/tooltip": "1.43.3",
         "jsdom": "^25.0.0",
         "marko": "^6.3.34",
         "playwright": "^1.62.1",
@@ -305,37 +305,37 @@
 
     "@vitest/utils": ["@vitest/utils@3.2.7", "", { "dependencies": { "@vitest/pretty-format": "3.2.7", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw=="],
 
-    "@zag-js/anatomy": ["@zag-js/anatomy@1.43.1", "", {}, "sha512-ypfnye/hPBGmMjJVEFA7+YbsxMz4P+bVFjUNWc+Gf+4q0ia2x3CZsqPCrO02xx8qgX5KTirOunlzThTgkUY3vw=="],
+    "@zag-js/anatomy": ["@zag-js/anatomy@1.43.3", "", {}, "sha512-KzosWgu0TTtdBNHPUZg2W8E5JsGsExQ8oGkLDmV6Sym9twaATU2YVMCWsfitq3Isss4099wNMsHdjEPK2UyCjw=="],
 
-    "@zag-js/checkbox": ["@zag-js/checkbox@1.43.1", "", { "dependencies": { "@zag-js/anatomy": "1.43.1", "@zag-js/core": "1.43.1", "@zag-js/dom-query": "1.43.1", "@zag-js/focus-visible": "1.43.1", "@zag-js/types": "1.43.1", "@zag-js/utils": "1.43.1" } }, "sha512-/XOullgmuXxhZ2v1+WD6NqmrOQhi8rjQw3S4oRsnNjHZ1zRwqfwFRZcNnqHqzeKXTRC/fqHY+maJQCezOPlOHQ=="],
+    "@zag-js/checkbox": ["@zag-js/checkbox@1.43.3", "", { "dependencies": { "@zag-js/anatomy": "1.43.3", "@zag-js/core": "1.43.3", "@zag-js/dom-query": "1.43.3", "@zag-js/focus-visible": "1.43.3", "@zag-js/types": "1.43.3", "@zag-js/utils": "1.43.3" } }, "sha512-1vikdGcAokmLSMAnHQo5lYG/DMMNej2FlaAxiuyna2n0XJy/VFhv/3+/FZNB9CAJBkeqwLm9kqo94c7iEL7cxA=="],
 
-    "@zag-js/collection": ["@zag-js/collection@1.43.1", "", { "dependencies": { "@zag-js/utils": "1.43.1" } }, "sha512-35xKbel9xFaTLKXW/mkrLi70ZwFCm2nGApB0alo9EvhVBIUyWdETqob3YVPvkAgu3aqf858kkQBymghf5gokrw=="],
+    "@zag-js/collection": ["@zag-js/collection@1.43.3", "", { "dependencies": { "@zag-js/utils": "1.43.3" } }, "sha512-POufSu17mxTic09DP3CD2sGiRCaNODv/gAYyotrM/ynWSeb2+TjSxlKxuiyQS0amiY+BwJ3+m5qJ4odmU9TLMQ=="],
 
-    "@zag-js/combobox": ["@zag-js/combobox@1.43.1", "", { "dependencies": { "@zag-js/anatomy": "1.43.1", "@zag-js/collection": "1.43.1", "@zag-js/core": "1.43.1", "@zag-js/dismissable": "1.43.1", "@zag-js/dom-query": "1.43.1", "@zag-js/focus-visible": "1.43.1", "@zag-js/live-region": "1.43.1", "@zag-js/popper": "1.43.1", "@zag-js/types": "1.43.1", "@zag-js/utils": "1.43.1" } }, "sha512-w5VHZwYYAL7UmnjaKGqeSBBj1ysww3FFkB/mqq20M3nlGKLmD1wOBCwfammkphBl6NM8NXeSvNkpORoCrHnCNg=="],
+    "@zag-js/combobox": ["@zag-js/combobox@1.43.3", "", { "dependencies": { "@zag-js/anatomy": "1.43.3", "@zag-js/collection": "1.43.3", "@zag-js/core": "1.43.3", "@zag-js/dismissable": "1.43.3", "@zag-js/dom-query": "1.43.3", "@zag-js/focus-visible": "1.43.3", "@zag-js/live-region": "1.43.3", "@zag-js/popper": "1.43.3", "@zag-js/types": "1.43.3", "@zag-js/utils": "1.43.3" } }, "sha512-qdm81w9PnR7/f/YNxie5iT50+7tXkKgiRJZEN59pYqwRA2AbwtE87jk7CQAuBVD1ko/wfcSBfIocoeltVKy2Kw=="],
 
-    "@zag-js/core": ["@zag-js/core@1.43.0", "", { "dependencies": { "@zag-js/dom-query": "1.43.0", "@zag-js/utils": "1.43.0" } }, "sha512-iIpTu/U1OHKXGjXq/bn/ek32nIKE0lmS2gLdihYmv1jtPXH8hVHaIOXR5KYGfOjMVb4+FiMMCZHlH9MWbLk2iA=="],
+    "@zag-js/core": ["@zag-js/core@1.43.3", "", { "dependencies": { "@zag-js/dom-query": "1.43.3", "@zag-js/utils": "1.43.3" } }, "sha512-afREBcZWvPLHz/2AxJeuAP2o6+o3V7NZO/MutLhdclKaVSBlPzCr6qqP9k8hq1zOxk1jogKT5VVGielzWDY2Dw=="],
 
-    "@zag-js/dismissable": ["@zag-js/dismissable@1.43.1", "", { "dependencies": { "@zag-js/dom-query": "1.43.1", "@zag-js/interact-outside": "1.43.1", "@zag-js/utils": "1.43.1" } }, "sha512-LkKpguLvFC83Ry2VG8zBqdluADO/7b0Pwef5aBZFHYTevhh3v+AOJThqtc6a9vd55k8k0UL1X8JGos3NYU0n9w=="],
+    "@zag-js/dismissable": ["@zag-js/dismissable@1.43.3", "", { "dependencies": { "@zag-js/dom-query": "1.43.3", "@zag-js/interact-outside": "1.43.3", "@zag-js/utils": "1.43.3" } }, "sha512-3znmDAC6qv7I9h/ZInVE+sFxE2wcBeQhT0bEiUjXAlgFGgaVmgA6A0ElGI7CDrot8qhgC88BZQisMWfYRRWgeg=="],
 
-    "@zag-js/dom-query": ["@zag-js/dom-query@1.43.1", "", { "dependencies": { "@zag-js/types": "1.43.1" } }, "sha512-EpxNajvnM5XfGKnKsJv0uWCA+4RbO/ve811IjZRyU56/H25JIitdmfWtqD6lhMtBkQuM6jkd5XEhkWWEJEXKeA=="],
+    "@zag-js/dom-query": ["@zag-js/dom-query@1.43.3", "", { "dependencies": { "@zag-js/types": "1.43.3" } }, "sha512-kpTTYMemMmHxhp4gyOllK7/Lf86AySTO+AlGds9iQM21eUwi1jvc9q3VTxP+qD/KwHePGftfPwkwxifC3iSGbw=="],
 
-    "@zag-js/focus-visible": ["@zag-js/focus-visible@1.43.1", "", { "dependencies": { "@zag-js/dom-query": "1.43.1" } }, "sha512-hHiyd7naxFDY1cHIOrhC7gjljJ8buxH3nGfFHaMKBdsJllWvcOUiqDcuc6Vce+RgrWgvJChj5y4o9j92cy1U9g=="],
+    "@zag-js/focus-visible": ["@zag-js/focus-visible@1.43.3", "", { "dependencies": { "@zag-js/dom-query": "1.43.3" } }, "sha512-32l21nQUI328nfNTe2adXyXj+8t1ltDaEm7IQGmhtAw/DuIKvjpEkhJZHL1zUSlp47QGNfuYGPeD+ZXaZWFWMA=="],
 
-    "@zag-js/interact-outside": ["@zag-js/interact-outside@1.43.1", "", { "dependencies": { "@zag-js/dom-query": "1.43.1", "@zag-js/utils": "1.43.1" } }, "sha512-KQCsiG2x1eYtf3BceYto3xKPbFpZP0weHcdxvOzr7Hcalrrlm4FcOn9KnfRYFWIVnF39CL8TAMptCnuoN8oAng=="],
+    "@zag-js/interact-outside": ["@zag-js/interact-outside@1.43.3", "", { "dependencies": { "@zag-js/dom-query": "1.43.3", "@zag-js/utils": "1.43.3" } }, "sha512-qgyAyWELSzFrHUtB6D7IzemI48NjX7E5oIDCXsz/DBPh+ybsK+pKMGsZkduTCK+uEqJcA/w+DAWaDUOxhjqvWA=="],
 
-    "@zag-js/live-region": ["@zag-js/live-region@1.43.1", "", {}, "sha512-Dy5kVWHJKwZSVH8HaTWvGJlc4+KLYfs81/vsnWm5sh1VR0Z+JhpXAwWfDUxbdPI64hIEMm5fFGZ5Zmo/bwCGzg=="],
+    "@zag-js/live-region": ["@zag-js/live-region@1.43.3", "", {}, "sha512-lB2ryGpRjTgbfJ5D86MQnvZRCJupKbpwS53jfCkEP0EBC9Tk7Crq9p0pobzXgH5U9fnjn4BPsqBSyuSOxPOJnw=="],
 
-    "@zag-js/popper": ["@zag-js/popper@1.43.1", "", { "dependencies": { "@floating-ui/dom": "^1.7.6", "@zag-js/dom-query": "1.43.1", "@zag-js/utils": "1.43.1" } }, "sha512-xqka/qkx3cdQ5lGH2xWqDKYGzAXcnvdfNTiQl8hSxDeyqcTTS8peitPscbikSBCT56i4dk5+72wKeDrSOuY9aw=="],
+    "@zag-js/popper": ["@zag-js/popper@1.43.3", "", { "dependencies": { "@floating-ui/dom": "^1.7.6", "@zag-js/dom-query": "1.43.3", "@zag-js/utils": "1.43.3" } }, "sha512-99PPQerLylh+ouG16d0Go0UgpLR3rCQvWMmJoO5Ti8+2Ww3aqBNLTqpF0rJuLPe1Ps4BfEt5Lr4dYhL1ixgbRQ=="],
 
     "@zag-js/qr-code": ["@zag-js/qr-code@1.43.3", "", { "dependencies": { "@zag-js/anatomy": "1.43.3", "@zag-js/core": "1.43.3", "@zag-js/dom-query": "1.43.3", "@zag-js/types": "1.43.3", "@zag-js/utils": "1.43.3", "proxy-memoize": "3.0.1", "uqr": "0.1.3" } }, "sha512-moSv0oTbO/XSAPnpPJGp5n4mpRlCsJYOaJW/I6zK1Ls6/YHWt7K9HUjZE06AwHwU+050ftivgWmXBlVgozc5GA=="],
 
     "@zag-js/select": ["@zag-js/select@1.43.3", "", { "dependencies": { "@zag-js/anatomy": "1.43.3", "@zag-js/collection": "1.43.3", "@zag-js/core": "1.43.3", "@zag-js/dismissable": "1.43.3", "@zag-js/dom-query": "1.43.3", "@zag-js/focus-visible": "1.43.3", "@zag-js/popper": "1.43.3", "@zag-js/types": "1.43.3", "@zag-js/utils": "1.43.3" } }, "sha512-vd5uKPOoRXXrHlL8VPNk5Mih6XRhIzXAon7emEupCe6UAAShqYnxumrLBbr5LifiePP93CGJx3rGn8RZky/OVg=="],
 
-    "@zag-js/tooltip": ["@zag-js/tooltip@1.43.1", "", { "dependencies": { "@zag-js/anatomy": "1.43.1", "@zag-js/core": "1.43.1", "@zag-js/dom-query": "1.43.1", "@zag-js/focus-visible": "1.43.1", "@zag-js/popper": "1.43.1", "@zag-js/types": "1.43.1", "@zag-js/utils": "1.43.1" } }, "sha512-jK++pmHbU5/fJIVcj00DvNY2BdoAyAvuML+105PxdH5pSD2yNLNmb20L/WKKy7XA0T9s++y13O1BhMlmRlIPZw=="],
+    "@zag-js/tooltip": ["@zag-js/tooltip@1.43.3", "", { "dependencies": { "@zag-js/anatomy": "1.43.3", "@zag-js/core": "1.43.3", "@zag-js/dom-query": "1.43.3", "@zag-js/focus-visible": "1.43.3", "@zag-js/popper": "1.43.3", "@zag-js/types": "1.43.3", "@zag-js/utils": "1.43.3" } }, "sha512-sBVhcejAQN5oDFE3PoGrvvjqOt5+9rHQjtjnnuhPZqeghsiX/IaL7AY8KelwDoNkMf2npN5i7loQvAZMZLVFaw=="],
 
-    "@zag-js/types": ["@zag-js/types@1.43.0", "", { "dependencies": { "csstype": "3.2.3" } }, "sha512-pheZyCiVjJaXBzbfoj/gMKXkZUo1D5JWd46QVYWonHJZIdUfDRDwBvDKcXGIHmpuq7fJrnGXbegAk0+D2aa4bw=="],
+    "@zag-js/types": ["@zag-js/types@1.43.3", "", { "dependencies": { "csstype": "3.2.3" } }, "sha512-QokzUgkJ7a/TRE8SAXqlm1XfiNDbyM8y+mx0PpmzHa8bvmWXLEe/Zx2TRz8aYoGim75NluYzDy3x+WWileF7uA=="],
 
-    "@zag-js/utils": ["@zag-js/utils@1.43.0", "", {}, "sha512-ZxkL+AuKRv/UGmmp5iZwmzfcVV7iWiDIrhYiMrKDKPJGdIPIFpMOisM+bTKYVkvn0jmCZV0CTF0jJm29hEV+LQ=="],
+    "@zag-js/utils": ["@zag-js/utils@1.43.3", "", {}, "sha512-9P9fvFFxuiDcLqX0BYgGNkf0/a/id32nHvQpwgv/Xv3b9n5yeyw2U8nKefpWr+1VfFsrpf2XMXiA2CDSWZgt2g=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -727,64 +727,6 @@
 
     "@publint/pack/tinyexec": ["tinyexec@1.3.0", "", {}, "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ=="],
 
-    "@zag-js/checkbox/@zag-js/core": ["@zag-js/core@1.43.1", "", { "dependencies": { "@zag-js/dom-query": "1.43.1", "@zag-js/utils": "1.43.1" } }, "sha512-P6wDhPgXxjBn+BFGjZcSDP7rNLpV8Pr8mySVj47BZv8zaCLYf4o9uqV1f5ns7m3LJ1x0e7s20sqw5rzlWPXHRw=="],
-
-    "@zag-js/checkbox/@zag-js/types": ["@zag-js/types@1.43.1", "", { "dependencies": { "csstype": "3.2.3" } }, "sha512-OOn9JRYoG7HmFmgqYL8qo1C6myZb5++cF5os/Mb4bqPWDYFUM12vHYlmaTNoG3ztypA1150YvEuIOpA4jacCww=="],
-
-    "@zag-js/checkbox/@zag-js/utils": ["@zag-js/utils@1.43.1", "", {}, "sha512-EaHwhiNPCok4VAeBd508rvq64f+FsBrhEEJdytZA0Eo8AqP5SMp85dOfBjM98PSbfncmiykBYb4zS1hyyYpkgQ=="],
-
-    "@zag-js/collection/@zag-js/utils": ["@zag-js/utils@1.43.1", "", {}, "sha512-EaHwhiNPCok4VAeBd508rvq64f+FsBrhEEJdytZA0Eo8AqP5SMp85dOfBjM98PSbfncmiykBYb4zS1hyyYpkgQ=="],
-
-    "@zag-js/combobox/@zag-js/core": ["@zag-js/core@1.43.1", "", { "dependencies": { "@zag-js/dom-query": "1.43.1", "@zag-js/utils": "1.43.1" } }, "sha512-P6wDhPgXxjBn+BFGjZcSDP7rNLpV8Pr8mySVj47BZv8zaCLYf4o9uqV1f5ns7m3LJ1x0e7s20sqw5rzlWPXHRw=="],
-
-    "@zag-js/combobox/@zag-js/types": ["@zag-js/types@1.43.1", "", { "dependencies": { "csstype": "3.2.3" } }, "sha512-OOn9JRYoG7HmFmgqYL8qo1C6myZb5++cF5os/Mb4bqPWDYFUM12vHYlmaTNoG3ztypA1150YvEuIOpA4jacCww=="],
-
-    "@zag-js/combobox/@zag-js/utils": ["@zag-js/utils@1.43.1", "", {}, "sha512-EaHwhiNPCok4VAeBd508rvq64f+FsBrhEEJdytZA0Eo8AqP5SMp85dOfBjM98PSbfncmiykBYb4zS1hyyYpkgQ=="],
-
-    "@zag-js/core/@zag-js/dom-query": ["@zag-js/dom-query@1.43.0", "", { "dependencies": { "@zag-js/types": "1.43.0" } }, "sha512-yQDR00jJj0tgrRH43QJx7NtQH+EBxQtEdFKMzG7c88xL1ZRtqXYpqNNSmCuGj5RTsEceQjEhAxeTJikUYp9M0g=="],
-
-    "@zag-js/dismissable/@zag-js/utils": ["@zag-js/utils@1.43.1", "", {}, "sha512-EaHwhiNPCok4VAeBd508rvq64f+FsBrhEEJdytZA0Eo8AqP5SMp85dOfBjM98PSbfncmiykBYb4zS1hyyYpkgQ=="],
-
-    "@zag-js/dom-query/@zag-js/types": ["@zag-js/types@1.43.1", "", { "dependencies": { "csstype": "3.2.3" } }, "sha512-OOn9JRYoG7HmFmgqYL8qo1C6myZb5++cF5os/Mb4bqPWDYFUM12vHYlmaTNoG3ztypA1150YvEuIOpA4jacCww=="],
-
-    "@zag-js/interact-outside/@zag-js/utils": ["@zag-js/utils@1.43.1", "", {}, "sha512-EaHwhiNPCok4VAeBd508rvq64f+FsBrhEEJdytZA0Eo8AqP5SMp85dOfBjM98PSbfncmiykBYb4zS1hyyYpkgQ=="],
-
-    "@zag-js/popper/@zag-js/utils": ["@zag-js/utils@1.43.1", "", {}, "sha512-EaHwhiNPCok4VAeBd508rvq64f+FsBrhEEJdytZA0Eo8AqP5SMp85dOfBjM98PSbfncmiykBYb4zS1hyyYpkgQ=="],
-
-    "@zag-js/qr-code/@zag-js/anatomy": ["@zag-js/anatomy@1.43.3", "", {}, "sha512-KzosWgu0TTtdBNHPUZg2W8E5JsGsExQ8oGkLDmV6Sym9twaATU2YVMCWsfitq3Isss4099wNMsHdjEPK2UyCjw=="],
-
-    "@zag-js/qr-code/@zag-js/core": ["@zag-js/core@1.43.3", "", { "dependencies": { "@zag-js/dom-query": "1.43.3", "@zag-js/utils": "1.43.3" } }, "sha512-afREBcZWvPLHz/2AxJeuAP2o6+o3V7NZO/MutLhdclKaVSBlPzCr6qqP9k8hq1zOxk1jogKT5VVGielzWDY2Dw=="],
-
-    "@zag-js/qr-code/@zag-js/dom-query": ["@zag-js/dom-query@1.43.3", "", { "dependencies": { "@zag-js/types": "1.43.3" } }, "sha512-kpTTYMemMmHxhp4gyOllK7/Lf86AySTO+AlGds9iQM21eUwi1jvc9q3VTxP+qD/KwHePGftfPwkwxifC3iSGbw=="],
-
-    "@zag-js/qr-code/@zag-js/types": ["@zag-js/types@1.43.3", "", { "dependencies": { "csstype": "3.2.3" } }, "sha512-QokzUgkJ7a/TRE8SAXqlm1XfiNDbyM8y+mx0PpmzHa8bvmWXLEe/Zx2TRz8aYoGim75NluYzDy3x+WWileF7uA=="],
-
-    "@zag-js/qr-code/@zag-js/utils": ["@zag-js/utils@1.43.3", "", {}, "sha512-9P9fvFFxuiDcLqX0BYgGNkf0/a/id32nHvQpwgv/Xv3b9n5yeyw2U8nKefpWr+1VfFsrpf2XMXiA2CDSWZgt2g=="],
-
-    "@zag-js/select/@zag-js/anatomy": ["@zag-js/anatomy@1.43.3", "", {}, "sha512-KzosWgu0TTtdBNHPUZg2W8E5JsGsExQ8oGkLDmV6Sym9twaATU2YVMCWsfitq3Isss4099wNMsHdjEPK2UyCjw=="],
-
-    "@zag-js/select/@zag-js/collection": ["@zag-js/collection@1.43.3", "", { "dependencies": { "@zag-js/utils": "1.43.3" } }, "sha512-POufSu17mxTic09DP3CD2sGiRCaNODv/gAYyotrM/ynWSeb2+TjSxlKxuiyQS0amiY+BwJ3+m5qJ4odmU9TLMQ=="],
-
-    "@zag-js/select/@zag-js/core": ["@zag-js/core@1.43.3", "", { "dependencies": { "@zag-js/dom-query": "1.43.3", "@zag-js/utils": "1.43.3" } }, "sha512-afREBcZWvPLHz/2AxJeuAP2o6+o3V7NZO/MutLhdclKaVSBlPzCr6qqP9k8hq1zOxk1jogKT5VVGielzWDY2Dw=="],
-
-    "@zag-js/select/@zag-js/dismissable": ["@zag-js/dismissable@1.43.3", "", { "dependencies": { "@zag-js/dom-query": "1.43.3", "@zag-js/interact-outside": "1.43.3", "@zag-js/utils": "1.43.3" } }, "sha512-3znmDAC6qv7I9h/ZInVE+sFxE2wcBeQhT0bEiUjXAlgFGgaVmgA6A0ElGI7CDrot8qhgC88BZQisMWfYRRWgeg=="],
-
-    "@zag-js/select/@zag-js/dom-query": ["@zag-js/dom-query@1.43.3", "", { "dependencies": { "@zag-js/types": "1.43.3" } }, "sha512-kpTTYMemMmHxhp4gyOllK7/Lf86AySTO+AlGds9iQM21eUwi1jvc9q3VTxP+qD/KwHePGftfPwkwxifC3iSGbw=="],
-
-    "@zag-js/select/@zag-js/focus-visible": ["@zag-js/focus-visible@1.43.3", "", { "dependencies": { "@zag-js/dom-query": "1.43.3" } }, "sha512-32l21nQUI328nfNTe2adXyXj+8t1ltDaEm7IQGmhtAw/DuIKvjpEkhJZHL1zUSlp47QGNfuYGPeD+ZXaZWFWMA=="],
-
-    "@zag-js/select/@zag-js/popper": ["@zag-js/popper@1.43.3", "", { "dependencies": { "@floating-ui/dom": "^1.7.6", "@zag-js/dom-query": "1.43.3", "@zag-js/utils": "1.43.3" } }, "sha512-99PPQerLylh+ouG16d0Go0UgpLR3rCQvWMmJoO5Ti8+2Ww3aqBNLTqpF0rJuLPe1Ps4BfEt5Lr4dYhL1ixgbRQ=="],
-
-    "@zag-js/select/@zag-js/types": ["@zag-js/types@1.43.3", "", { "dependencies": { "csstype": "3.2.3" } }, "sha512-QokzUgkJ7a/TRE8SAXqlm1XfiNDbyM8y+mx0PpmzHa8bvmWXLEe/Zx2TRz8aYoGim75NluYzDy3x+WWileF7uA=="],
-
-    "@zag-js/select/@zag-js/utils": ["@zag-js/utils@1.43.3", "", {}, "sha512-9P9fvFFxuiDcLqX0BYgGNkf0/a/id32nHvQpwgv/Xv3b9n5yeyw2U8nKefpWr+1VfFsrpf2XMXiA2CDSWZgt2g=="],
-
-    "@zag-js/tooltip/@zag-js/core": ["@zag-js/core@1.43.1", "", { "dependencies": { "@zag-js/dom-query": "1.43.1", "@zag-js/utils": "1.43.1" } }, "sha512-P6wDhPgXxjBn+BFGjZcSDP7rNLpV8Pr8mySVj47BZv8zaCLYf4o9uqV1f5ns7m3LJ1x0e7s20sqw5rzlWPXHRw=="],
-
-    "@zag-js/tooltip/@zag-js/types": ["@zag-js/types@1.43.1", "", { "dependencies": { "csstype": "3.2.3" } }, "sha512-OOn9JRYoG7HmFmgqYL8qo1C6myZb5++cF5os/Mb4bqPWDYFUM12vHYlmaTNoG3ztypA1150YvEuIOpA4jacCww=="],
-
-    "@zag-js/tooltip/@zag-js/utils": ["@zag-js/utils@1.43.1", "", {}, "sha512-EaHwhiNPCok4VAeBd508rvq64f+FsBrhEEJdytZA0Eo8AqP5SMp85dOfBjM98PSbfncmiykBYb4zS1hyyYpkgQ=="],
-
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
@@ -804,7 +746,5 @@
     "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
-    "@zag-js/select/@zag-js/dismissable/@zag-js/interact-outside": ["@zag-js/interact-outside@1.43.3", "", { "dependencies": { "@zag-js/dom-query": "1.43.3", "@zag-js/utils": "1.43.3" } }, "sha512-qgyAyWELSzFrHUtB6D7IzemI48NjX7E5oIDCXsz/DBPh+ybsK+pKMGsZkduTCK+uEqJcA/w+DAWaDUOxhjqvWA=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marko-zag",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "description": "Zag.js v1 bindings for Marko 6 \u2014 SSR-safe state machine adapter",
   "license": "MIT",
   "type": "module",
@@ -43,9 +43,9 @@
     "lint:package": "publint"
   },
   "dependencies": {
-    "@zag-js/core": "^1.43.0",
-    "@zag-js/types": "^1.43.0",
-    "@zag-js/utils": "^1.43.0"
+    "@zag-js/core": "1.43.3",
+    "@zag-js/types": "1.43.3",
+    "@zag-js/utils": "1.43.3"
   },
   "peerDependencies": {
     "marko": "^6.3.34"
@@ -55,11 +55,11 @@
     "@marko/type-check": "^2.0.0",
     "@marko/vite": "5",
     "@vitest/browser": "3.2.7",
-    "@zag-js/checkbox": "^1.43.0",
-    "@zag-js/combobox": "^1.43.0",
-    "@zag-js/qr-code": "^1.43.0",
-    "@zag-js/select": "^1.43.0",
-    "@zag-js/tooltip": "^1.43.0",
+    "@zag-js/checkbox": "1.43.3",
+    "@zag-js/combobox": "1.43.3",
+    "@zag-js/qr-code": "1.43.3",
+    "@zag-js/select": "1.43.3",
+    "@zag-js/tooltip": "1.43.3",
     "jsdom": "^25.0.0",
     "marko": "^6.3.34",
     "playwright": "^1.62.1",

--- a/tests/type-assertions.ts
+++ b/tests/type-assertions.ts
@@ -97,15 +97,16 @@ export const noForeignPart = apiGetter().getPatternProps();
 
 // --- there is no ZagProps alias, and why ------------------------------------
 
-// `ZagSchema<M>` recovers a module's schema through `Machine<infer T>`, but
-// the schema types its own members loosely: indexing it yields `any`. These
-// pins document that, so nobody reintroduces a `ZagProps<M>` alias believing
-// it constrains anything. (An earlier revision shipped one aliased to the
-// whole schema; `props?:` typed nothing and no assertion caught it.)
+// `ZagSchema<M>` recovers a module's schema through `Machine<infer T>`. As of
+// @zag-js/* 1.43.3, `schema.props` is a real (`RequiredBy<Props, ...>`) type,
+// not `any` — zag tightened this upstream. We still don't reintroduce a
+// `ZagProps<M>` alias: `checkbox.Props` (below) remains the precision path a
+// component's `Input` should extend, since it is what the docs point at and
+// isn't tied to the schema's internal defaulting shape.
 type IsAny<T> = 0 extends 1 & T ? "any" : "notany";
 
 declare const schemaProps: IsAny<ZagSchema<typeof checkbox>["props"]>;
-export const schemaPropsIsAny: "any" = schemaProps;
+export const schemaPropsIsReal: "notany" = schemaProps;
 
 // A module's OWN exported Props is a real type — this is the precision path,
 // via MachineInput on a component's Input, and it is what the docs point at.


### PR DESCRIPTION
## Summary

Align every `@zag-js/*` dependency to exact `1.43.3` (from `^1.43.0`, installed `1.43.0`), absorb the one type fallout, and prep the `2.0.0-rc.3` release.

## Changes

- `chore(deps)`: `@zag-js/core`, `@zag-js/types`, `@zag-js/utils` (dependencies) and `@zag-js/checkbox`, `@zag-js/combobox`, `@zag-js/qr-code`, `@zag-js/select`, `@zag-js/tooltip` (devDependencies) pinned to exact `1.43.3` — no caret range, matching the repo's style rule (carets → exact pins). `bun.lock` re-resolved to a single `1.43.3` for every `@zag-js/*` entry, no duplicates.
- `fix(types)`: zag 1.43.3 tightened `MachineSchema` so `schema.props` is now a real `RequiredBy<Props, PropsWithDefault>` type instead of `any`. Updated the regression pin in `tests/type-assertions.ts` to assert `"notany"` instead of `"any"`. No `src/` changes needed — this is the only fallout from the bump.
- `chore(release)`: `package.json` version → `2.0.0-rc.3`; `CHANGELOG.md` gets a `## [2.0.0-rc.3] - 2026-08-30` section and updated compare links.

No external users, no backwards-compatibility commitment on this adapter — breaking changes are free, and none were needed beyond the one type pin update.

## Test plan

All 4 gates green on `chore/rc3` @ latest, verified independently by the operator:

- [x] `bun run check` (marko-type-check) — 0 errors
- [x] `bun run test` (jsdom + SSR) — 71/71 passed (matches rc.2 baseline: 71)
- [x] `bun run test:browser` (real Chromium) — 18/18 passed (matches rc.2 baseline: 18)
- [x] `bun run lint:package` (publint) — all good

## Related

- Consumer: marko-ui PR [#6](https://github.com/svallory/marko-ui/pull/6) — unified all `@zag-js/*` at `1.43.3` and moved to TypeScript `^7.0.2`; already type-checks clean against zag 1.43.3 with marko-zag rc.2, motivating this alignment bump.

**Not** to be merged, tagged, or published here — `bun run release` is operator-run and 1Password-backed.

---
🤖 AI-assisted — operator Saulo Vallory, session `11dec89e-e32c-484d-a010-58d15e3b68e0`.