### PR TITLE
chore(release): marko-zag 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-09-09
+
 ### Changed
 
 - Root `typescript` devDependency moves back from `^7.0.2` to `^6.0.3` —
@@ -540,7 +542,8 @@ service.rev                           service
 
 - `stripOwnProps` native-attrs helper.
 
-[Unreleased]: https://github.com/svallory/marko-zag/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/svallory/marko-zag/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/svallory/marko-zag/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/svallory/marko-zag/compare/v1.2.1...v2.0.0
 [2.0.0-rc.3]: https://github.com/svallory/marko-zag/compare/v2.0.0-rc.2...v2.0.0-rc.3
 [2.0.0-rc.2]: https://github.com/svallory/marko-zag/compare/v2.0.0-rc.1...v2.0.0-rc.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marko-zag",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Zag.js v1 bindings for Marko 6 — SSR-safe state machine adapter",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Patch release 2.0.1.

- Root `typescript` devDependency moves back from `^7.0.2` to `^6.0.3` — marko's tooling (`@marko/type-check`, `@marko/vite`) has issues with TypeScript 7 (native `tsgo`).
- Added an optional `typescript` peerDependency (`^5.0.0 || ^6.0.0`) so a TS 7 install surfaces an npm warning; see README for the compatibility note.
- CHANGELOG retitled `[Unreleased]` → `[2.0.1]`, fresh empty `[Unreleased]` opened, comparison links updated.

## Gates

- `bun install`: clean
- `bun run check`: 0 errors
- `bun run test`: 61 jsdom/node passed, 10 SSR passed
- `bun run test:browser`: 18 Chromium tests passed
- `bun run lint:package` (publint): all good

## AI-note

Operator: Saulo Vallory
Session: e2759fa7-aa28-4ebe-81c3-b51702758bac