### PR TITLE
feat(machine-input): Own type param — declared members shadow native attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `MachineInput<Tag, Props, Own>` gains an optional third type parameter,
+  `Own`. Keys present in `Own` are omitted from the native/`Props` side
+  before intersecting, so a component member that shares a name with a
+  native attribute (e.g. a `<@title>` attr tag on `div`, colliding with the
+  native `title: AttrString`) no longer collapses into an unsatisfiable
+  intersection. Two-param usage is unchanged (`Own` defaults to `{}`, a
+  no-op).
+
 ## [2.0.1] - 2026-09-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
   native attribute (e.g. a `<@title>` attr tag on `div`, colliding with the
   native `title: AttrString`) no longer collapses into an unsatisfiable
   intersection. Two-param usage is unchanged (`Own` defaults to `{}`, a
-  no-op).
+  no-op). Note: `Own` always wins, so declaring an `id` member in `Own`
+  overrides the auto-generated stable `id?: string`.
 
 ## [2.0.1] - 2026-09-09
 

--- a/docs/api/machine-input.md
+++ b/docs/api/machine-input.md
@@ -6,16 +6,20 @@ description: "Input type helper for components wrapping a Zag machine."
 # `MachineInput`
 
 ```ts
-type MachineInput<Tag, Props> = Marko.Input<Tag> &
-  Omit<Props, "id"> & { id?: string };
+type MachineInput<Tag, Props, Own = {}> = Omit<
+  Marko.Input<Tag> & Omit<Props, "id"> & { id?: string },
+  keyof Own
+> &
+  Own;
 ```
 
 Input type for a Marko component wrapping a Zag machine: the native tag's
 attributes intersected with the machine's full `Props` type.
 
-The only adjustment is `id`: Zag's `CommonProperties` requires it, but the
-[`<zag>`](/api/tags/#zag) tag generates a stable one
-automatically — so consumers may omit it (and may still override it).
+The only adjustment on the native/`Props` side is `id`: Zag's
+`CommonProperties` requires it, but the [`<zag>`](/api/tags/#zag) tag
+generates a stable one automatically — so consumers may omit it (and may
+still override it).
 
 ## Type parameters
 
@@ -23,6 +27,7 @@ automatically — so consumers may omit it (and may still override it).
 | --- | --- |
 | `Tag` | The native tag name whose attributes the component forwards (e.g. `"input"`, `"div"`). |
 | `Props` | The machine module's exported `Props` type (e.g. `switchMachine.Props`). |
+| `Own` | Extra members the component itself declares on its `Input` (e.g. an `<@title>` attr tag). Keys present in `Own` are omitted from the native/`Props` side before intersecting, so a declared member sharing a name with a native attribute isn't forced into an unsatisfiable intersection with that attribute's native type. Defaults to `{}` (no-op). |
 
 ## Example
 
@@ -33,6 +38,27 @@ import type { MachineInput } from "marko-zag";
 export type Input = MachineInput<"input", switchMachine.Props> & {
   // Marko bind-shorthand sugar (`checked:=state.on`):
   checkedChange?: (checked: boolean) => void;
+};
+```
+
+## Shadowing a native attribute
+
+A component's own declared member sometimes shares a name with a native
+attribute — e.g. a `<@title>` attr tag on a `div`, which collides with the
+native `title: AttrString` attribute. Plain `&` intersection would then
+force an unsatisfiable type at every consumer. Pass the colliding member as
+`Own` so it resolves to the declared type instead:
+
+```ts
+import * as dialogMachine from "@zag-js/dialog";
+import type { MachineInput } from "marko-zag";
+
+export type Input = MachineInput<
+  "div",
+  dialogMachine.Props,
+  { title?: Marko.AttrTag<{ content: Marko.Body }> }
+> & {
+  title?: Marko.AttrTag<{ content: Marko.Body }>;
 };
 ```
 

--- a/docs/api/machine-input.md
+++ b/docs/api/machine-input.md
@@ -21,6 +21,10 @@ The only adjustment on the native/`Props` side is `id`: Zag's
 generates a stable one automatically — so consumers may omit it (and may
 still override it).
 
+> `Own` always wins: if it declares its own `id` member (e.g. `Own = {id:
+> number}`), that member replaces the `id?: string` guarantee above —
+> the stable auto-generated `id` is no longer part of the type.
+
 ## Type parameters
 
 | Parameter | Description |

--- a/src/machine-input.ts
+++ b/src/machine-input.ts
@@ -10,6 +10,12 @@
  * forwards (e.g. `"input"`, `"div"`).
  * @typeParam Props - The machine module's exported `Props` type
  * (e.g. `switchMachine.Props`).
+ * @typeParam Own - Extra members the component itself declares on its
+ * `Input` (e.g. an `<@title>` attr tag). Keys present in `Own` are omitted
+ * from the native/`Props` side before intersecting, so a declared member
+ * that shares a name with a native attribute (like `title`) is not forced
+ * into an unsatisfiable intersection with that attribute's native type.
+ * Defaults to `{}`, which is a no-op.
  *
  * @example
  * ```ts
@@ -22,6 +28,19 @@
  * };
  * ```
  *
+ * A component that declares a member colliding with a native attribute
+ * (e.g. `title` on `div`) passes that member as `Own` so it is not
+ * intersected with the native attribute's type:
+ * ```ts
+ * export type Input = MachineInput<
+ *   "div",
+ *   dialogMachine.Props,
+ *   { title?: Marko.AttrTag<{ content: Marko.Body }> }
+ * > & {
+ *   title?: Marko.AttrTag<{ content: Marko.Body }>;
+ * };
+ * ```
+ *
  * @remarks
  * Controlled-prop semantics follow Zag v1: passing a controlled prop (e.g.
  * `open=`) **without** wiring its change handler pins the machine to that
@@ -30,5 +49,8 @@
  * (`defaultOpen`, `defaultValue`, …) for the uncontrolled, initial-value
  * path.
  */
-export type MachineInput<Tag, Props> = Marko.Input<Tag> &
-  Omit<Props, "id"> & { id?: string };
+export type MachineInput<Tag, Props, Own = {}> = Omit<
+  Marko.Input<Tag> & Omit<Props, "id"> & { id?: string },
+  keyof Own
+> &
+  Own;

--- a/tests/type-assertions.ts
+++ b/tests/type-assertions.ts
@@ -137,6 +137,20 @@ export const collidingTitleIsAttrTag: Marko.AttrTag<TitleAttrTag> | undefined =
 // @ts-expect-error native `title` (AttrString) is no longer assignable once Own declares it
 export const collidingTitleRejectsNativeString: CollidingInput["title"] = "x";
 
+// Mutual-extends equality: `title` must be EXACTLY `Own`'s declared type, not
+// merely assignable to it. A naive plain intersection (no `Omit` of the
+// native side) would type `title` as `AttrString & AttrTag<TitleAttrTag>`,
+// which is still assignable to `AttrTag<TitleAttrTag> | undefined` (the
+// check above), but is NOT assignable *from* it, since the native
+// `AttrString` conjunct requires satisfying `string | false | null` too.
+// This pair only both pass when the native side has actually been omitted.
+type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+type CollidingTitleIsExactlyOwn = Exact<
+  CollidingInput["title"],
+  Marko.AttrTag<TitleAttrTag> | undefined
+>;
+export const collidingTitleIsExactlyOwnType: CollidingTitleIsExactlyOwn = true;
+
 // A plain, non-colliding member named `title` in `Own` is likewise the
 // declared type verbatim.
 type PlainOwnInput = MachineInput<"div", checkbox.Props, { title?: number }>;

--- a/tests/type-assertions.ts
+++ b/tests/type-assertions.ts
@@ -14,6 +14,7 @@
 import type * as checkbox from "@zag-js/checkbox";
 import type { MachineSchema } from "@zag-js/core";
 import type { MarkoService } from "../src/machine.ts";
+import type { MachineInput } from "../src/machine-input.ts";
 import type { PropTypes } from "../src/prop-types.ts";
 import type { ZagApi, ZagModule, ZagSchema } from "../src/zag-module.ts";
 import type Service from "../src/tags/zag-machine.marko";
@@ -117,6 +118,48 @@ export const moduleOwnPropsIsReal: "notany" = realProps;
 // needs it for.
 declare const svcOverSchema: MarkoService<ZagSchema<typeof checkbox>>;
 export const serviceTakesSchema: MarkoService<any> = svcOverSchema;
+
+// --- MachineInput's third type param (Own) ----------------------------------
+
+// A component whose Input declares an attr-tag member colliding with a
+// native attribute (e.g. `title` on `div`) passes it as `Own` so it resolves
+// to the declared type, not an unsatisfiable intersection with the native
+// attribute's type.
+type TitleAttrTag = { content: Marko.Body };
+type CollidingInput = MachineInput<
+  "div",
+  checkbox.Props,
+  { title?: Marko.AttrTag<TitleAttrTag> }
+>;
+declare const collidingTitle: CollidingInput["title"];
+export const collidingTitleIsAttrTag: Marko.AttrTag<TitleAttrTag> | undefined =
+  collidingTitle;
+// @ts-expect-error native `title` (AttrString) is no longer assignable once Own declares it
+export const collidingTitleRejectsNativeString: CollidingInput["title"] = "x";
+
+// A plain, non-colliding member named `title` in `Own` is likewise the
+// declared type verbatim.
+type PlainOwnInput = MachineInput<"div", checkbox.Props, { title?: number }>;
+declare const plainOwnTitle: PlainOwnInput["title"];
+export const plainOwnTitleIsNumber: number | undefined = plainOwnTitle;
+// @ts-expect-error Own's declared type wins over the native string attribute
+export const plainOwnTitleRejectsString: PlainOwnInput["title"] = "x";
+
+// Without a third argument (or with Own left as `{}`), an undeclared `title`
+// stays the native attribute's own type.
+type NoOwnInput = MachineInput<"div", checkbox.Props>;
+declare const nativeTitle: NoOwnInput["title"];
+export const nativeTitleIsNativeAttrString: PropTypes["div"]["title"] =
+  nativeTitle;
+
+// Two-param usage is unchanged: everything from Tag + Props (minus `id`) is
+// still present, and `id` is still optional `string`.
+type TwoParamInput = MachineInput<"input", checkbox.Props>;
+declare const twoParamId: TwoParamInput["id"];
+export const twoParamIdIsOptionalString: string | undefined = twoParamId;
+declare const twoParamChecked: TwoParamInput["checked"];
+export const twoParamCheckedIsFromProps: checkbox.Props["checked"] =
+  twoParamChecked;
 
 // --- old tag names do not resolve ------------------------------------------
 


### PR DESCRIPTION
## Problem

Components compose `MachineInput<\"div\", Props> & { title?: Marko.AttrTag<{content: Marko.Body}> }`. TS `&` intersects — a declared member colliding with a native attribute (e.g. `title: AttrString = string | false | null` on `Marko.HTML.Div`) becomes an unsatisfiable intersection. Result: TS2322 at every `<@title>` consumer.

Verified in marko-ui against a component declaring a `title` attr-tag on top of `MachineInput<\"div\", Props>`.

## Fix

`MachineInput` gains an optional third type param `Own` (default `{}`):

```ts
type MachineInput<Tag extends string, Props = {}, Own = {}> =
  Omit<NativeAndProps, keyof Own> & Own
```

The native+`Props` composition is `Omit`'d by `keyof Own` before intersecting with `Own`. This removes the colliding keys from the native side so the intersection resolves to the component-declared type instead of `never`.

## Backward compatibility

`Own` defaults to `{}`, so `keyof Own` is `never` and `Omit<X, never>` is the identity type — the two-param call signature is byte-compatible with before. Covered by type-level assertions (not just inspection) in `tests/type-assertions.ts`.

## Coverage

Type assertions added for:
- colliding attr-tag member (`title`) resolves to the `Own` type
- plain string member also named `title` — unaffected
- undeclared `title` stays native `AttrString`
- existing two-param usage — unchanged

## Gates

- `bun run check` — clean
- unit tests — 61 jsdom + 10 SSR passing
- `test:browser` — 18 passing
- `lint:package` — clean

## Notes

- No `.changeset/` directory exists in this repo; per its own CLAUDE.md convention, the entry was added directly to `CHANGELOG.md` under `[Unreleased]` (minor bump, additive type param).
- No `tsd`/`expect-type` dependency present; type coverage follows the repo's existing `tests/type-assertions.ts` plain-assertion convention rather than introducing new tooling.

---
AI-assisted: implemented by Claude (Claude Code) under operator Saulo Vallory, session `381d38ce-8411-4dd5-a776-4be5070289c6`.